### PR TITLE
removed Atom Discussions link

### DIFF
--- a/socialLinks.py
+++ b/socialLinks.py
@@ -13,7 +13,6 @@ links = {
     "Asciinema": "https://asciinema.org/~{}",
     "Ask Fedora": "https://ask.fedoraproject.org/u/{}",
     "AskFM": "https://ask.fm/{}",
-    "Atom Discussions": "https://discuss.atom.io/u/{}/summary",
     "Audiojungle": "https://audiojungle.net/user/{}",
     "Avizo": "https://www.avizo.cz/{}/",
     "BLIP.fm": "https://blip.fm/{}",


### PR DESCRIPTION
Atom Discussion link was returning the following error;
![Screenshot_20210818-010709](https://user-images.githubusercontent.com/74001397/129813307-ef3bc28b-1983-4f04-9aa7-61d6a21891d7.jpg)
